### PR TITLE
Added definitions of 'number of weeks' and 'earnings as an employee'

### DIFF
--- a/openfisca_aotearoa/definitions/earnings_as_an_employee.md
+++ b/openfisca_aotearoa/definitions/earnings_as_an_employee.md
@@ -1,0 +1,15 @@
+# DEFINITIONS: EARNINGS AS AN EMPLOYEE
+
+**Term name:** EarningsAsAnEmployee
+
+**UUID:** organiccoders/brk:/1234/ed84652e-8011-43dc-aeef-72e5ad3593f4
+
+**Definition:** Earnings as an employee, in relation to any person and any tax year, means all PAYE income payments of the person for the tax year.
+
+**Legislation:** Schedule 2/Part1/5 Compensation for Live Organ Donors Act 2016
+
+**Refers to:** earnings as an employee has the meaning given by section 6(1) of the Accident Compensation Act 2001
+
+**Narrower than:** ‘Earnings’
+
+**Related:** ‘Employee’

--- a/openfisca_aotearoa/definitions/number_of_weeks.md
+++ b/openfisca_aotearoa/definitions/number_of_weeks.md
@@ -1,0 +1,15 @@
+# DEFINITIONS: NUMBER OF WEEKS
+
+**Term name:** NumberOfWeeks
+
+**UUID:** organiccoders/brk:/1234/12a0780a-b516-44f1-bdb7-6ec4b6c3e174
+
+**Definition:** number of weeks is (a) the number of full weeks plus any part week (expressed as a portion of a week), if the period is 1 week or more; and (b) a part week (expressed as a portion of a week), if the period is less than 1 week
+
+**Legislation:** Part 1, Section 4
+
+**Narrower than:** http://purl.org/dc/terms/LocationPeriodOrJurisdiction
+
+**Related:** PeriodOfTime (altLabel:Period)
+
+**Note:** Time event (ref DCAT temporal purl.org/dc/terms/temporal) or CPSV ‘period of time’ An interval of time that is named or defined by its start and end dates. http://purl.org/dc/terms/PeriodOfTime

--- a/openfisca_aotearoa/variables/live_organ_donor_compensation.py
+++ b/openfisca_aotearoa/variables/live_organ_donor_compensation.py
@@ -83,7 +83,7 @@ class sum_of_earnings_in_last_52_weeks(Variable):
     value_type = float
     entity = Person
     label = u"Total earnings over last 52 weeks"
-    reference = "http://organiccoders.allengeer.com/brk-1234-abcdfcrg234356/"
+    reference = "https://github.com/OrganicCoders/openfisca-aotearoa/blob/data-definitions/openfisca_aotearoa/definitions/earnings_as_an_employee.md"
     definition_period = YEAR
 
 
@@ -92,7 +92,7 @@ class earnings_period_in_weeks(Variable):
     default_value = 52
     entity = Person
     label = u"The number of weeks over which earnings have been earned"
-    reference = "http://organiccoders.allengeer.com/definitions-number-of-weeks/"
+    reference = "https://github.com/OrganicCoders/openfisca-aotearoa/blob/data-definitions/openfisca_aotearoa/definitions/number_of_weeks.md"
     definition_period = YEAR
 
 


### PR DESCRIPTION
* Added definitions folder containing definitions for 'number of weeks' and 'earnings as an employee'
* Updated the references in variables/live_organ_donor_compensation.py to reference these definitions

Note that if we go with this and this pull request is actioned, we will need to update the repository and branch name in the URLs. There could be a way to resolve this in future using something like [python-feedparser](https://github.com/unode/python-feedparser/blob/master/docs/resolving-relative-links.rst) in the pipeline to resolve relative links into actual links.